### PR TITLE
 Add the missing hook class to update the shipment number UI

### DIFF
--- a/app/views/spree/admin/orders/_stock_contents.html.erb
+++ b/app/views/spree/admin/orders/_stock_contents.html.erb
@@ -54,7 +54,7 @@
 </tr>
 
 <tr class="show-tracking total">
-  <td colspan="5">
+  <td colspan="5" class="tracking-value">
     <% if shipment.tracking.present? %>
       <strong><%= Spree.t(:tracking) %>:</strong> <%= shipment.tracking %>
     <% else %>


### PR DESCRIPTION
Solidus update the UI after the update shipment number async call using
the hook `.tracking-value`. Without this hook the update shipment number
doesn't show the new value.

https://github.com/solidusio/solidus/blob/1302a7d86b5108a449b59a83d0b4a2e9a2d58e00/backend/app/views/spree/admin/orders/_shipment.html.erb